### PR TITLE
Fix http and conda relations; add jupyter-base-url config option.

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -19,6 +19,10 @@ options:
     default: "7e6785caad25e33930bc03fac4994a434a21bc8401817b7efa28f53619fa9c29"
     description: |
       SHA checksum for installer
+  jupyter-base-url:
+    description: |
+      Base URL of the notebook, if reverse-proxied.
+    type: string
   jupyter-web-password:
     description: |
       Jupyter web password - if not set, this charm will generate a password for you and expose it via web ui.

--- a/reactive/jupyter_notebook.py
+++ b/reactive/jupyter_notebook.py
@@ -81,6 +81,7 @@ def init_configure_jupyter_notebook():
     ctxt = {
         'port': conf.get('jupyter-web-port'),
         'password_hash': generate_hash(kv.get('password')),
+        'base_url': conf.get('jupyter-base-url'),
     }
 
     templating.render(
@@ -112,13 +113,13 @@ def jupyter_init_available():
         hookenv.status_set('blocked', "Jupyter could not start - Please DEBUG")
 
 
-@when('endpoint.conda.joined')
+@when('conda.available')
 @when_not('conda.relation.data.available')
 def set_conda_relation_data():
     """Set conda endpoint relation data
     """
     conf = hookenv.config()
-    endpoint = endpoint_from_flag('endpoint.conda.joined')
+    endpoint = endpoint_from_flag('conda.available')
 
     ctxt = {'url': conf.get('conda-installer-url'),
             'sha': conf.get('conda-installer-sha256')}
@@ -134,11 +135,11 @@ def set_conda_relation_data():
     set_flag('conda.relation.data.available')
 
 
-@when('endpoint.http.joined',
+@when('http.available',
       'jupyter-notebook.init.available')
 def configure_http():
     conf = hookenv.config()
-    endpoint = endpoint_from_flag('endpoint.http.joined')
+    endpoint = endpoint_from_flag('http.available')
     endpoint.configure(port=conf.get('jupyter-web-port'))
 
 

--- a/templates/jupyter_notebook_config.py.j2
+++ b/templates/jupyter_notebook_config.py.j2
@@ -14,5 +14,11 @@ c.NotebookApp.password = "{{password_hash}}"
 # Don't try another port if this port is unavailable.
 c.NotebookApp.port_retries = 0
 
-#Answer yes to all prompts (such as "are you sure you want to shutdown the notebook")
+# Answer yes to all prompts (such as "are you sure you want to shutdown the notebook")
 c.NotebookApp.answer_yes = True
+
+{% if base_url %}
+# Configure base_url if we're reverse-proxied to behind a base path.
+c.NotebookApp.base_url = {{base_url}}
+
+{% endif %}


### PR DESCRIPTION
I'm trying to reverse-proxy jupyter behind haproxy with path-based
routing, which requires setting base_url in the jupyter config

I also found that the http relation hook was not
firing. interface:http sets {endpoint-name}.available, so I've updated
the reactive states accordingly. Found a similar issue in
interface:conda.